### PR TITLE
Remove automatic code checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           nox-session: ${{ matrix.nox-session }}
-          git-username: ${{ secrets.GIT_USER }}
-          git-password: ${{ secrets.GIT_PASS }}
 ```
 
 ## Inputs
+
+This action expects the workflow to check out the repository before running
+`nox`.
 
 * `python-version`: The python version to use. Required.
 
@@ -59,21 +60,6 @@ jobs:
   Optional. Default: `".[dev-noxfile]"`.
 
   Projects not having any extra dependency to run nox can just use `"nox"` here.
-
-* `checkout`: Whether to checkout the code. Optional. Default: `true`.
-
-  When true, this action will first setup git using the
-  [`gh-action-setup-git`](https://github.com/frequenz-floss/gh-action-setup-git/),
-  passing `git-username` and `git-password` as credentials if provided, and then
-  fetch the code using [`actions/checkout`](https://github.com/actions/checkout).
-
-* `git-username`: The username to use for the git configuration. Optional.
-
-  This is particularly useful if `pip` needs to access a private repository.
-
-* `git-password`: The password to use for the git configuration. Optional.
-
-  This is particularly useful if `pip` needs to access a private repository.
 
 ## Permissions
 

--- a/action.yaml
+++ b/action.yaml
@@ -20,21 +20,6 @@ inputs:
       to run nox can just use `"nox"`.
     required: false
     default: ".[dev-noxfile]"
-  checkout:
-    description: >
-      Whether to checkout the repository or not. If set to `false`, the action
-      will not checkout the repository. This is useful when the repository is
-      already checked out.
-    required: false
-    default: "true"
-  git-username:
-    description: >
-      The username to use for the Git credentials.
-    required: false
-  git-password:
-    description: >
-      The password to use for the Git credentials.
-    required: false
 
 
 # Refer to the following link(s) for more information on the composite run steps:
@@ -45,19 +30,6 @@ runs:
     - name: Print environment (debug)
       shell: bash
       run: env
-
-    - name: Setup Git
-      if: inputs.checkout != 'false'
-      uses: frequenz-floss/gh-action-setup-git@f9d86a01228ee1cadaac5224d4d7626f1eb23f90 # v1.0.0
-      with:
-        username: ${{ inputs.git-username }}
-        password: ${{ inputs.git-password }}
-
-    - name: Fetch sources
-      if: inputs.checkout != 'false'
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        submodules: true
 
     - name: Setup Python
       uses: frequenz-floss/gh-action-setup-python-with-deps@bc560ff517d3606e1291eed46a603a9f7bfe8697 # v1.0.3


### PR DESCRIPTION
Also remove the associated inputs: checkout, git-username, and git-password. The checkout step takes a lot of inputs we either should forward or keep it too inflexible. It is better that users take care of code checkout.

This is a breaking change!
